### PR TITLE
Set default ValueChangeMode to ON_CHANGE

### DIFF
--- a/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -38,7 +38,7 @@ public class PasswordField extends GeneratedVaadinPasswordField<PasswordField>
      */
     public PasswordField() {
         super.setValue(getEmptyValue());
-        setValueChangeMode(ValueChangeMode.ON_BLUR);
+        setValueChangeMode(ValueChangeMode.ON_CHANGE);
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -119,6 +119,11 @@ public class PasswordField extends GeneratedVaadinPasswordField<PasswordField>
         addValueChangeListener(listener);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default value is {@link ValueChangeMode#ON_CHANGE}.
+     */
     @Override
     public ValueChangeMode getValueChangeMode() {
         return currentMode;

--- a/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -37,7 +37,7 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea>
      */
     public TextArea() {
         super.setValue(getEmptyValue());
-        setValueChangeMode(ValueChangeMode.ON_BLUR);
+        setValueChangeMode(ValueChangeMode.ON_CHANGE);
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -137,6 +137,11 @@ public class TextArea extends GeneratedVaadinTextArea<TextArea>
         addValueChangeListener(listener);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default value is {@link ValueChangeMode#ON_CHANGE}.
+     */
     @Override
     public ValueChangeMode getValueChangeMode() {
         return currentMode;

--- a/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -137,6 +137,11 @@ public class TextField extends GeneratedVaadinTextField<TextField>
         addValueChangeListener(listener);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default value is {@link ValueChangeMode#ON_CHANGE}.
+     */
     @Override
     public ValueChangeMode getValueChangeMode() {
         return currentMode;

--- a/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -37,7 +37,7 @@ public class TextField extends GeneratedVaadinTextField<TextField>
      */
     public TextField() {
         super.setValue(getEmptyValue());
-        setValueChangeMode(ValueChangeMode.ON_BLUR);
+        setValueChangeMode(ValueChangeMode.ON_CHANGE);
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
@@ -44,25 +44,25 @@ public class ValueChangeModeButtonProvider {
 
     private ValueChangeMode getDifferentMode(ValueChangeMode valueChangeMode) {
         switch (valueChangeMode) {
-        case EAGER:
-            return ValueChangeMode.ON_CHANGE;
-        case ON_CHANGE:
-            return ValueChangeMode.EAGER;
-        default:
-            throw new IllegalArgumentException(
-                    "Unexpected value change mode: " + valueChangeMode);
+            case EAGER:
+                return ValueChangeMode.ON_CHANGE;
+            case ON_CHANGE:
+                return ValueChangeMode.EAGER;
+            default:
+                throw new IllegalArgumentException(
+                        "Unexpected value change mode: " + valueChangeMode);
         }
     }
 
     private String getToggleButtonText(ValueChangeMode valueChangeMode) {
         switch (valueChangeMode) {
-        case EAGER:
-            return "Sync value only on committed changes";
-        case ON_CHANGE:
-            return "Sync value eagerly on each change";
-        default:
-            throw new IllegalArgumentException(
-                    "Unexpected value change mode: " + valueChangeMode);
+            case EAGER:
+                return "Sync value only on committed changes";
+            case ON_CHANGE:
+                return "Sync value eagerly on each change";
+            default:
+                throw new IllegalArgumentException(
+                        "Unexpected value change mode: " + valueChangeMode);
         }
     }
 }

--- a/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
@@ -24,15 +24,18 @@ public class ValueChangeModeButtonProvider {
 
     private final HasValueChangeMode<?, ?> elementWithChangeMode;
 
-    ValueChangeModeButtonProvider(HasValueChangeMode<?, ?> elementWithChangeMode) {
+    ValueChangeModeButtonProvider(
+            HasValueChangeMode<?, ?> elementWithChangeMode) {
         this.elementWithChangeMode = elementWithChangeMode;
     }
 
     NativeButton getToggleValueSyncButton() {
-        NativeButton toggleValueSync = new NativeButton(getToggleButtonText(elementWithChangeMode.getValueChangeMode()));
+        NativeButton toggleValueSync = new NativeButton(getToggleButtonText(
+                elementWithChangeMode.getValueChangeMode()));
         toggleValueSync.setId(TOGGLE_BUTTON_ID);
         toggleValueSync.addClickListener(event -> {
-            ValueChangeMode newMode = getDifferentMode(elementWithChangeMode.getValueChangeMode());
+            ValueChangeMode newMode = getDifferentMode(
+                    elementWithChangeMode.getValueChangeMode());
             elementWithChangeMode.setValueChangeMode(newMode);
             toggleValueSync.setText(getToggleButtonText(newMode));
         });
@@ -41,23 +44,25 @@ public class ValueChangeModeButtonProvider {
 
     private ValueChangeMode getDifferentMode(ValueChangeMode valueChangeMode) {
         switch (valueChangeMode) {
-            case EAGER:
-                return ValueChangeMode.ON_BLUR;
-            case ON_BLUR:
-                return ValueChangeMode.EAGER;
-            default:
-                throw new IllegalArgumentException("Unexpected value change mode: " + valueChangeMode);
+        case EAGER:
+            return ValueChangeMode.ON_CHANGE;
+        case ON_CHANGE:
+            return ValueChangeMode.EAGER;
+        default:
+            throw new IllegalArgumentException(
+                    "Unexpected value change mode: " + valueChangeMode);
         }
     }
 
     private String getToggleButtonText(ValueChangeMode valueChangeMode) {
         switch (valueChangeMode) {
-            case EAGER:
-                return "Sync value on blur event";
-            case ON_BLUR:
-                return "Sync value on each change";
-            default:
-                throw new IllegalArgumentException("Unexpected value change mode: " + valueChangeMode);
+        case EAGER:
+            return "Sync value only on committed changes";
+        case ON_CHANGE:
+            return "Sync value eagerly on each change";
+        default:
+            throw new IllegalArgumentException(
+                    "Unexpected value change mode: " + valueChangeMode);
         }
     }
 }


### PR DESCRIPTION
This new mode syncs value also when pressing enter. `ValueChangeMode.BLUR` was removed from the demo because it doesn't bring much value for these particular components, even though it might be useful for some `HasValueChangeMode` components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/62)
<!-- Reviewable:end -->
