### PR TITLE
Make the button text more meaningful

### DIFF
--- a/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/demo/ValueChangeModeButtonProvider.java
@@ -57,9 +57,9 @@ public class ValueChangeModeButtonProvider {
     private String getToggleButtonText(ValueChangeMode valueChangeMode) {
         switch (valueChangeMode) {
             case EAGER:
-                return "Sync value only on committed changes";
+            return "Switch to sync value only on committed changes";
             case ON_CHANGE:
-                return "Sync value eagerly on each change";
+            return "Switch to sync value eagerly on each change";
             default:
                 throw new IllegalArgumentException(
                         "Unexpected value change mode: " + valueChangeMode);


### PR DESCRIPTION
The origin text is more like a statement, when the demo is shown in
Vcom, the user get confused with the current state of the component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/99)
<!-- Reviewable:end -->
