### PR TITLE
Bugfix in SlotHelpers.java

### DIFF
--- a/src/main/java/com/vaadin/flow/component/textfield/SlotHelpers.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/SlotHelpers.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
@@ -54,6 +55,7 @@ class SlotHelpers {
      */
     public static void clearSlot(HasElement parent, String slot) {
         getElementsInSlot(parent, slot)
+                .collect(Collectors.toList())
                 .forEach(parent.getElement()::removeChild);
     }
 

--- a/src/test/java/com/vaadin/flow/component/textfield/SlotHelpersTest.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/SlotHelpersTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.textfield;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
+
+/**
+ * Tests for the {@link SlotHelpers}.
+ */
+public class SlotHelpersTest {
+
+	private static final String TEST_SLOT = "testSlot";
+	private static final String OTHER_SLOT = "otherSlot";
+
+	@Test
+	public void clearSlotShouldOnlyRemoveElementsFromMatchingSlot() {
+		Element div=ElementFactory.createDiv();
+		div.appendChild(span(TEST_SLOT));
+		div.appendChild(span(OTHER_SLOT));
+		
+		HasElement hasElement=() -> div;
+		
+		assertThat(SlotHelpers.getElementsInSlot(hasElement, TEST_SLOT).count(), is(1L));
+		assertThat(SlotHelpers.getElementsInSlot(hasElement, OTHER_SLOT).count(), is(1L));
+		
+		SlotHelpers.clearSlot(hasElement, TEST_SLOT); 
+		
+		assertThat(SlotHelpers.getElementsInSlot(hasElement, TEST_SLOT).count(), is(0L));
+		assertThat(SlotHelpers.getElementsInSlot(hasElement, OTHER_SLOT).count(), is(1L));
+	}
+	
+	private static Element span(String slot) {
+		Element span = ElementFactory.createSpan();
+		span.setAttribute("slot", slot);
+		return span;
+	}
+}


### PR DESCRIPTION
stream related bugfix

stacktrace was:

aused by: java.lang.IllegalArgumentException: Cannot get element with index 1 when there are 1 children
	at com.vaadin.flow.dom.Node.getChild(Node.java:111) ~[flow-server-1.0.2.jar:?]
	at com.vaadin.flow.dom.Element.getChild(Element.java:190) ~[flow-server-1.0.2.jar:?]
	at java.util.stream.IntPipeline$4$1.accept(IntPipeline.java:250) ~[?:1.8.0_181]
	at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:110) ~[?:1.8.0_181]
	at java.util.Spliterator$OfInt.forEachRemaining(Spliterator.java:693) ~[?:1.8.0_181]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481) ~[?:1.8.0_181]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471) ~[?:1.8.0_181]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[?:1.8.0_181]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[?:1.8.0_181]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_181]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418) ~[?:1.8.0_181]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/100)
<!-- Reviewable:end -->
