### PR TITLE
removed obsolete plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,15 +118,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>runTests</id>


### PR DESCRIPTION
Jetty plugin is also defined in parent project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/124)
<!-- Reviewable:end -->
