### PR TITLE
1.2.1 cherry pick

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,15 +118,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>runTests</id>

--- a/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldIT.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/tests/PasswordFieldIT.java
@@ -55,14 +55,14 @@ public class PasswordFieldIT extends ComponentDemoTest {
             blur();
         }
         waitUntilTextsEqual("Password field value changed from '' to 'a'",
-                passwordFieldValueDiv.getText());
+                passwordFieldValueDiv);
 
         passwordField.sendKeys(Keys.BACK_SPACE);
         if (toggleBlur) {
             blur();
         }
         waitUntilTextsEqual("Password field value changed from 'a' to ''",
-                passwordFieldValueDiv.getText());
+                passwordFieldValueDiv);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class PasswordFieldIT extends ComponentDemoTest {
         verifyThemeVariantsBeingToggled();
     }
 
-    private void waitUntilTextsEqual(String expected, String actual) {
-        waitUntil(driver -> expected.equals(actual));
+    private void waitUntilTextsEqual(String expected, WebElement valueDiv) {
+        waitUntil(driver -> expected.equals(valueDiv.getText()));
     }
 }

--- a/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaIT.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaIT.java
@@ -57,14 +57,14 @@ public class TextAreaIT extends ComponentDemoTest {
             blur();
         }
         waitUntilTextsEqual("Text area value changed from '' to 'a'",
-                textFieldValueDiv.getText());
+                textFieldValueDiv);
 
         textArea.sendKeys(Keys.BACK_SPACE);
         if (toggleBlur) {
             blur();
         }
         waitUntilTextsEqual("Text area value changed from 'a' to ''",
-                textFieldValueDiv.getText());
+                textFieldValueDiv);
     }
 
     @Test
@@ -115,8 +115,8 @@ public class TextAreaIT extends ComponentDemoTest {
         Assert.assertEquals("", message.getText());
     }
 
-    private void waitUntilTextsEqual(String expected, String actual) {
-        waitUntil(driver -> expected.equals(actual));
+    private void waitUntilTextsEqual(String expected, WebElement valueDiv) {
+        waitUntil(driver -> expected.equals(valueDiv.getText()));
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldIT.java
+++ b/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldIT.java
@@ -55,14 +55,14 @@ public class TextFieldIT extends ComponentDemoTest {
             blur();
         }
         waitUntilTextsEqual("Text field value changed from '' to 'a'",
-                textFieldValueDiv.getText());
+                textFieldValueDiv);
 
         textField.sendKeys(Keys.BACK_SPACE);
         if (toggleBlur) {
             blur();
         }
         waitUntilTextsEqual("Text field value changed from 'a' to ''",
-                textFieldValueDiv.getText());
+                textFieldValueDiv);
     }
 
     @Test
@@ -73,8 +73,8 @@ public class TextFieldIT extends ComponentDemoTest {
                 "placeholder text");
     }
 
-    private void waitUntilTextsEqual(String expected, String actual) {
-        waitUntil(driver -> expected.equals(actual));
+    private void waitUntilTextsEqual(String expected, WebElement valueDiv) {
+        waitUntil(driver -> expected.equals(valueDiv.getText()));
     }
 
     @Test


### PR DESCRIPTION
Cherry-picks:
- Fix waitUntilTextsEqual in ITs to really wait for the text (#121) 
- removed obsolete plugin declaration (#124)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/141)
<!-- Reviewable:end -->
