### PR TITLE
Correct HasAutocapitalize javadoc (#159)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/textfield/HasAutocapitalize.java
+++ b/src/main/java/com/vaadin/flow/component/textfield/HasAutocapitalize.java
@@ -34,8 +34,10 @@ public interface HasAutocapitalize extends HasElement {
      * If not set, devices may apply their own default.
      * <p>
      * <em>Note:</em> <a href=
-     * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocapitalize">This
-     * is only supported by Chrome and Safari</a>.
+     * "https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize">
+     * This attribute doesn't affect behavior when typing on a physical keyboard. Instead,
+     * it affects the behavior of other input mechanisms, such as virtual keyboards on
+     * mobile devices and voice input. It is only supported by Chrome and Safari</a>.
      *
      * @param autocapitalize
      *            the {@code autocapitalize} value, or {@code null} to unset


### PR DESCRIPTION
* Correct HasAutocapitalize javadoc

fixes #158

* Review fixes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/161)
<!-- Reviewable:end -->
