### PR TITLE
BigDecimalField: localize decimal separator, add setLocale

### DIFF
--- a/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
+++ b/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
@@ -19,7 +19,6 @@ import java.math.BigDecimal;
 import java.util.Locale;
 
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
@@ -55,34 +54,18 @@ public class BigDecimalFieldPage extends Div {
                 e -> field.setEnabled(!field.isEnabled()));
         toggleEnabled.setId("toggle-enabled");
 
+        NativeButton setFrenchLocale = new NativeButton("Set French locale",
+                e -> field.setLocale(Locale.FRENCH));
+        setFrenchLocale.setId("set-french-locale");
+
         BigDecimalField fieldWithClearButton = new BigDecimalField();
         fieldWithClearButton.setClearButtonVisible(true);
         fieldWithClearButton.setId("clear-big-decimal-field");
         fieldWithClearButton.addValueChangeListener(this::logValueChangeEvent);
 
-        NativeButton addFieldWithFrenchLocale = new NativeButton(
-                "Set French locale and add new field",
-                e -> addFieldWithFrenchLocale());
-        addFieldWithFrenchLocale.setId("add-french-locale-field");
-
         Div buttons = new Div(setValueWithScale, toggleReadOnly, toggleRequired,
-                toggleEnabled, addFieldWithFrenchLocale);
+                toggleEnabled, setFrenchLocale);
         add(field, buttons, fieldWithClearButton, messageContainer);
-    }
-
-    private void addFieldWithFrenchLocale() {
-        UI.getCurrent().setLocale(Locale.FRENCH);
-        BigDecimalField frenchField = new BigDecimalField("French locale");
-        frenchField.addValueChangeListener(this::logValueChangeEvent);
-        frenchField.setId("french-locale-field");
-        add(frenchField);
-
-        NativeButton setValueToFrenchLocaleField = new NativeButton(
-                "Set value to French locale field", e -> {
-                    frenchField.setValue(new BigDecimal("1.2"));
-                });
-        setValueToFrenchLocaleField.setId("set-value-to-french-locale-field");
-        add(setValueToFrenchLocaleField);
     }
 
     private void logValueChangeEvent(

--- a/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
+++ b/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPage.java
@@ -16,8 +16,10 @@
 package com.vaadin.flow.component.textfield.tests;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import com.vaadin.flow.component.AbstractField.ComponentValueChangeEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
@@ -58,9 +60,29 @@ public class BigDecimalFieldPage extends Div {
         fieldWithClearButton.setId("clear-big-decimal-field");
         fieldWithClearButton.addValueChangeListener(this::logValueChangeEvent);
 
+        NativeButton addFieldWithFrenchLocale = new NativeButton(
+                "Set French locale and add new field",
+                e -> addFieldWithFrenchLocale());
+        addFieldWithFrenchLocale.setId("add-french-locale-field");
+
         Div buttons = new Div(setValueWithScale, toggleReadOnly, toggleRequired,
-                toggleEnabled);
+                toggleEnabled, addFieldWithFrenchLocale);
         add(field, buttons, fieldWithClearButton, messageContainer);
+    }
+
+    private void addFieldWithFrenchLocale() {
+        UI.getCurrent().setLocale(Locale.FRENCH);
+        BigDecimalField frenchField = new BigDecimalField("French locale");
+        frenchField.addValueChangeListener(this::logValueChangeEvent);
+        frenchField.setId("french-locale-field");
+        add(frenchField);
+
+        NativeButton setValueToFrenchLocaleField = new NativeButton(
+                "Set value to French locale field", e -> {
+                    frenchField.setValue(new BigDecimal("1.2"));
+                });
+        setValueToFrenchLocaleField.setId("set-value-to-french-locale-field");
+        add(setValueToFrenchLocaleField);
     }
 
     private void logValueChangeEvent(

--- a/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -174,6 +174,31 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
         assertValueChange(2, 300, null);
     }
 
+    @Test
+    public void setLocale_addField_parsingAndFormattingUseLocalizedDecimalSeparator() {
+        clickElementWithJs("add-french-locale-field");
+        field = $(BigDecimalFieldElement.class).id("french-locale-field");
+
+        // Parsing value with comma from client to server
+        field.setValue("5,5");
+        assertValueChange(1, null, "5.5");
+
+        // Formatting server-side value to have comma at client-side
+        clickElementWithJs("set-value-to-french-locale-field");
+        Assert.assertEquals("1,2", field.getValue());
+        assertValueChange(2, "5.5", "1.2");
+    }
+
+    @Test
+    public void setLocale_addField_fieldAcceptsLocalizedDecimalSeparatorAsInput() {
+        clickElementWithJs("add-french-locale-field");
+        field = $(BigDecimalFieldElement.class).id("french-locale-field");
+        Assert.assertEquals(
+                "BigDecimalField with French locale has unexpected pattern for "
+                        + "invalid input prevention (the _enabledCharPattern property)",
+                "[\\d-+,]", field.getPropertyString("_enabledCharPattern"));
+    }
+
     // Always checking the count of fired events to make sure it doesn't fire
     // duplicates or extra value-changes in any scenario
     private void assertValueChange(int expectedCount, Object expectedOldValue,

--- a/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -175,24 +175,34 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void setLocale_addField_parsingAndFormattingUseLocalizedDecimalSeparator() {
-        clickElementWithJs("add-french-locale-field");
-        field = $(BigDecimalFieldElement.class).id("french-locale-field");
+    public void setLocale_parsingAndFormattingUseLocalizedDecimalSeparator() {
+        clickElementWithJs("set-french-locale");
 
         // Parsing value with comma from client to server
         field.setValue("5,5");
         assertValueChange(1, null, "5.5");
 
         // Formatting server-side value to have comma at client-side
-        clickElementWithJs("set-value-to-french-locale-field");
-        Assert.assertEquals("1,2", field.getValue());
-        assertValueChange(2, "5.5", "1.2");
+        clickElementWithJs("set-value-with-scale");
+        Assert.assertEquals("1,200", field.getValue());
+        assertValueChange(2, "5.5", "1.200");
     }
 
     @Test
-    public void setLocale_addField_fieldAcceptsLocalizedDecimalSeparatorAsInput() {
-        clickElementWithJs("add-french-locale-field");
-        field = $(BigDecimalFieldElement.class).id("french-locale-field");
+    public void setValue_setLocale_currentInputValueReformatted() {
+        field.setValue("1.1");
+
+        clickElementWithJs("set-french-locale");
+
+        Assert.assertEquals("1,1", field.getValue());
+
+        // shouldn't fire extra event when formatting the value
+        assertValueChange(1, null, "1.1");
+    }
+
+    @Test
+    public void setLocale_fieldAcceptsLocalizedDecimalSeparatorAsInput() {
+        clickElementWithJs("set-french-locale");
         Assert.assertEquals(
                 "BigDecimalField with French locale has unexpected pattern for "
                         + "invalid input prevention (the _enabledCharPattern property)",

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -63,7 +63,7 @@ public class BigDecimalField
     private boolean required;
 
     private static char getDecimalSeparatorFromUILocale() {
-        return Optional.of(UI.getCurrent())
+        return Optional.ofNullable(UI.getCurrent())
                 .map(ui -> new DecimalFormatSymbols(ui.getLocale())
                         .getDecimalSeparator())
                 .orElse('.');

--- a/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -38,10 +38,23 @@
         return 'vaadin-big-decimal-field';
       }
 
+      static get properties() {
+        return {
+          _decimalSeparator: {
+            type: String,
+            value: '.',
+            observer: '__decimalSeparatorChanged'
+          }
+        }
+      }
+
       ready() {
         super.ready();
         this.inputElement.setAttribute('inputmode', 'numeric');
-        this._enabledCharPattern = '[\\d-+.]';
+      }
+
+      __decimalSeparatorChanged(separator) {
+        this._enabledCharPattern = '[\\d-+' + separator + ']';
       }
 
     }

--- a/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -53,8 +53,12 @@
         this.inputElement.setAttribute('inputmode', 'numeric');
       }
 
-      __decimalSeparatorChanged(separator) {
+      __decimalSeparatorChanged(separator, oldSeparator) {
         this._enabledCharPattern = '[\\d-+' + separator + ']';
+
+        if (this.value && oldSeparator) {
+          this.value = this.value.split(oldSeparator).join(separator);
+        }
       }
 
     }


### PR DESCRIPTION
The decimal separator is determined by `UI.getLocale` unless explicitly set by the developer.

Changing the decimal separator (via the Locale) updates the current input value and invalid input prevention at client-side. The server-side parser and formatter use the current decimal separator.

Fix #258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field-flow/262)
<!-- Reviewable:end -->
