### PR TITLE
fix: use inputmode decimal for BigDecimalField

### DIFF
--- a/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
+++ b/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/BigDecimalFieldPageIT.java
@@ -48,8 +48,8 @@ public class BigDecimalFieldPageIT extends AbstractComponentIT {
     }
 
     @Test
-    public void shouldHaveInputModeNumeric() {
-        Assert.assertEquals("numeric",
+    public void shouldHaveInputModeDecimal() {
+        Assert.assertEquals("decimal",
                 field.$("input").first().getAttribute("inputmode"));
     }
 

--- a/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
+++ b/vaadin-text-field-flow/src/main/resources/META-INF/resources/frontend/vaadin-big-decimal-field.js
@@ -85,7 +85,7 @@
 
       ready() {
         super.ready();
-        this.inputElement.setAttribute('inputmode', 'numeric');
+        this.inputElement.setAttribute('inputmode', 'decimal');
       }
 
       __decimalSeparatorChanged(separator, oldSeparator) {


### PR DESCRIPTION
Fix for https://vaadin.com/forum/thread/18310939/big-decimal-text-field-error-on-ios