### PR TITLE
Add Helper API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-text-field-flow-parent</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin TextField Flow Parent</name>
 

--- a/vaadin-text-field-flow-demo/pom.xml
+++ b/vaadin-text-field-flow-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-text-field-flow-demo</artifactId>

--- a/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
+++ b/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
@@ -62,7 +62,6 @@ public class TextFieldView extends DemoView {
         textFieldClearButton();
         textFieldFocusShortcut();
         textFieldHelperText();
-        textFieldHelperTextVariants();
         passwordFieldBasic(); // PasswordField
         passwordFieldHideRevealButton();
         emailFieldBasic(); // EmailField
@@ -77,7 +76,6 @@ public class TextFieldView extends DemoView {
         textAreaMaxHeight();
         textAreaMinHeight();
         textAreaHelperText();
-        textAreaHelperTextVariant();
         prefixAndSuffix(); // Prefix and suffix
         prefixAndSuffixSearch();
         validationMinMaxLength(); // Validation
@@ -85,6 +83,7 @@ public class TextFieldView extends DemoView {
         customValidation();
         themeVariantsTextAlign(); // Theme Variants
         themeVariantsSmallSize();
+        helperTextVariants();
         styling(); // Styling
     }
 
@@ -194,27 +193,6 @@ public class TextFieldView extends DemoView {
 
         div.add(helperFieldText, new Text("  "), helperFieldComponent);
         addCard("Text field", "Helper Text and Component", div);
-    }
-
-    private void textFieldHelperTextVariants() {
-        Div div = new Div();
-        // begin-source-example
-        // source-example-heading: Text field Helper Variant
-        TextField helperFieldBelow = new TextField();
-        helperFieldBelow.setHelperText("Helper Text displayed below the field");
-
-        TextField helperFieldAbove = new TextField();
-        helperFieldAbove.setHelperText("Helper Text displayed above the field");
-        helperFieldAbove
-              .addThemeVariants(TextFieldVariant.LUMO_HELPER_ABOVE_FIELD);
-
-        add(helperFieldBelow, helperFieldAbove);
-        // end-source-example
-
-        div.getStyle().set("display","flex");
-        helperFieldBelow.getStyle().set("margin-right","20px");
-        div.add(helperFieldBelow, helperFieldAbove);
-        addCard("Text field", "Text field Helper Variant", div);
     }
 
     private void passwordFieldBasic() {
@@ -445,29 +423,6 @@ public class TextFieldView extends DemoView {
         addCard("Text Area", "Helper text and helper component", div);
     }
 
-    private void textAreaHelperTextVariant() {
-        Div div = new Div();
-        // begin-source-example
-        // source-example-heading: Helper Variant
-        TextArea textAreaBelow = new TextArea();
-        textAreaBelow.setPlaceholder("Write here ...");
-        textAreaBelow.setHelperText("Helper Text is below the field");
-
-        TextArea textAreaAbove = new TextArea();
-        textAreaAbove.setPlaceholder("Write here ...");
-        textAreaAbove.setHelperText("Helper Text is above the field");
-        textAreaAbove.addThemeVariants(TextAreaVariant.LUMO_HELPER_ABOVE_FIELD);
-
-        add(textAreaBelow, textAreaAbove);
-        // end-source-example
-
-        div.getStyle().set("display", "flex");
-        textAreaBelow.getStyle().set("margin-right", "20px");
-        div.add(textAreaBelow, textAreaAbove);
-
-        addCard("Text Area", "Helper Variant", div);
-    }
-
     private void prefixAndSuffix() {
         Div div = new Div();
         // begin-source-example
@@ -634,6 +589,30 @@ public class TextFieldView extends DemoView {
         add(textField);
         // end-source-example
         addCard("Theme Variants", "Small size", textField);
+    }
+
+    private void helperTextVariants() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: Helper Variant
+
+        TextField helperFieldAbove = new TextField();
+        helperFieldAbove.setHelperText("Helper Text displayed above the field");
+        helperFieldAbove
+              .addThemeVariants(TextFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+
+        TextArea textAreaAbove = new TextArea();
+        textAreaAbove.setPlaceholder("Write here ...");
+        textAreaAbove.setHelperText("Helper Text is above the field");
+        textAreaAbove.addThemeVariants(TextAreaVariant.LUMO_HELPER_ABOVE_FIELD);
+
+        add(helperFieldAbove, textAreaAbove);
+        // end-source-example
+
+        div.getStyle().set("display", "flex");
+        helperFieldAbove.getStyle().set("margin-right", "20px");
+        div.add(helperFieldAbove, textAreaAbove);
+        addCard("Theme Variants", "Helper Variant", div);
     }
 
     private void styling() {

--- a/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
+++ b/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
@@ -72,6 +72,7 @@ public class TextFieldView extends DemoView {
         numberFieldWithValueLimits();
         numberFieldWithStep();
         bigDecimalField();
+        numberFieldWithHelperText();
         textAreaBasic(); // TextArea
         textAreaMaxHeight();
         textAreaMinHeight();
@@ -182,11 +183,11 @@ public class TextFieldView extends DemoView {
         Div div = new Div();
         // begin-source-example
         // source-example-heading: Helper Text and Component
-        TextField helperFieldText = new TextField();
-        helperFieldText.setHelperText("Helper Text");
+        TextField helperFieldText = new TextField("First name");
+        helperFieldText.setHelperText("Enter all your first names");
 
-        TextField helperFieldComponent = new TextField();
-        helperFieldComponent.setHelperComponent(new Span("Helper text displayed in Span"));
+        TextField helperFieldComponent = new TextField("Last Name");
+        helperFieldComponent.setHelperComponent(new Span("Family name"));
 
         add(helperFieldText, helperFieldComponent);
         // end-source-example
@@ -198,7 +199,7 @@ public class TextFieldView extends DemoView {
     private void textFieldHelperTextVariants() {
         Div div = new Div();
         // begin-source-example
-        // source-example-heading: TextField Helper Variant
+        // source-example-heading: Text field Helper Variant
         TextField helperFieldBelow = new TextField();
         helperFieldBelow.setHelperText("Helper Text displayed below the field");
 
@@ -213,7 +214,7 @@ public class TextFieldView extends DemoView {
         div.getStyle().set("display","flex");
         helperFieldBelow.getStyle().set("margin-right","20px");
         div.add(helperFieldBelow, helperFieldAbove);
-        addCard("Text field", "TextField Helper Variant", div);
+        addCard("Text field", "Text field Helper Variant", div);
     }
 
     private void passwordFieldBasic() {
@@ -344,7 +345,7 @@ public class TextFieldView extends DemoView {
                 taxValue = BigDecimal.ZERO;
             } else {
                 taxValue = e.getValue().multiply(new BigDecimal("0.24"))
-                        .setScale(2, RoundingMode.HALF_EVEN);
+                      .setScale(2, RoundingMode.HALF_EVEN);
             }
             tax.setText("VAT 24%: $" + taxValue);
         });
@@ -354,6 +355,27 @@ public class TextFieldView extends DemoView {
         add(bigDecimalField, tax);
         // end-source-example
         addCard("Number field", "Big decimal field", bigDecimalField, tax);
+    }
+
+    private void numberFieldWithHelperText() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: Number fields with helper text
+        NumberField numberField = new NumberField("Total Salary");
+        numberField
+              .setHelperText("Any valid number can be put in a NumberField");
+
+        IntegerField integerField = new IntegerField("Your age");
+        integerField
+              .setHelperText("Only integers can be put in an IntegerField");
+
+        add(numberField, integerField);
+        // end-source-example
+
+        numberField.setId("number-field-helper-id");
+        integerField.setId("integer-field-helper-id");
+        div.add(numberField, new Text(" "), integerField);
+        addCard("Number field", "Number fields with helper text", div);
     }
 
     private void textAreaBasic() {
@@ -402,14 +424,16 @@ public class TextFieldView extends DemoView {
     private void textAreaHelperText() {
         Div div = new Div();
         // begin-source-example
-        // source-example-heading: TextArea Helper Text and Component
-        TextArea textAreaHelperText = new TextArea();
+        // source-example-heading: Text area Helper Text and Component
+        TextArea textAreaHelperText = new TextArea("Overview");
         textAreaHelperText.setPlaceholder("Write here ...");
-        textAreaHelperText.setHelperText("Helper Text");
+        textAreaHelperText
+              .setHelperText("Short description of your current position");
 
-        TextArea textAreaHelperComponent = new TextArea();
+        TextArea textAreaHelperComponent = new TextArea("Feedback");
         textAreaHelperComponent.setPlaceholder("Write here ...");
-        textAreaHelperComponent.setHelperComponent(new Span("Helper Text"));
+        textAreaHelperComponent.setHelperComponent(new Span(
+              "Here you can share what you've liked and what can be improved in the next lesson"));
 
         add(textAreaHelperText, textAreaHelperComponent);
         // end-source-example
@@ -417,7 +441,7 @@ public class TextFieldView extends DemoView {
         textAreaHelperText.setId("text-area-with-helper-text");
         textAreaHelperText.getStyle().set("margin-right","20px");
         div.add(textAreaHelperText, textAreaHelperComponent);
-        addCard("Text Area", "TextArea Helper Text and Component", div);
+        addCard("Text Area", "Text area Helper Text and Component", div);
     }
 
     private void textAreaHelperTextVariant() {

--- a/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
+++ b/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextAreaVariant;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.TextFieldVariant;
 import com.vaadin.flow.component.textfield.demo.entity.Person;
@@ -60,6 +61,8 @@ public class TextFieldView extends DemoView {
         textFieldAutoselect();
         textFieldClearButton();
         textFieldFocusShortcut();
+        textFieldHelperText();
+        textFieldHelperTextVariants();
         passwordFieldBasic(); // PasswordField
         passwordFieldHideRevealButton();
         emailFieldBasic(); // EmailField
@@ -72,6 +75,8 @@ public class TextFieldView extends DemoView {
         textAreaBasic(); // TextArea
         textAreaMaxHeight();
         textAreaMinHeight();
+        textAreaHelperText();
+        textAreaHelperTextVariant();
         prefixAndSuffix(); // Prefix and suffix
         prefixAndSuffixSearch();
         validationMinMaxLength(); // Validation
@@ -171,6 +176,44 @@ public class TextFieldView extends DemoView {
 
         textField.setId("shortcut-field");
         this.addCard("Text field", "Focus shortcut usage", textField);
+    }
+
+    private void textFieldHelperText() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: Helper Text and Component
+        TextField helperFieldText = new TextField();
+        helperFieldText.setHelperText("Helper Text");
+
+        TextField helperFieldComponent = new TextField();
+        helperFieldComponent.setHelperComponent(new Span("Helper text displayed in Span"));
+
+        add(helperFieldText, helperFieldComponent);
+        // end-source-example
+
+        div.add(helperFieldText, new Text("  "), helperFieldComponent);
+        addCard("Text field", "Helper Text and Component", div);
+    }
+
+    private void textFieldHelperTextVariants() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: TextField Helper Variant
+        TextField helperFieldBelow = new TextField();
+        helperFieldBelow.setHelperText("Helper Text displayed below the field");
+
+        TextField helperFieldAbove = new TextField();
+        helperFieldAbove.setHelperText("Helper Text displayed above the field");
+        helperFieldAbove
+              .addThemeVariants(TextFieldVariant.LUMO_HELPER_ABOVE_FIELD);
+
+        add(helperFieldBelow, helperFieldAbove);
+        // end-source-example
+
+        div.getStyle().set("display","flex");
+        helperFieldBelow.getStyle().set("margin-right","20px");
+        div.add(helperFieldBelow, helperFieldAbove);
+        addCard("Text field", "TextField Helper Variant", div);
     }
 
     private void passwordFieldBasic() {
@@ -354,6 +397,50 @@ public class TextFieldView extends DemoView {
         textArea.getStyle().set("padding", "0");
         textArea.setId("text-area-with-min-height");
         addCard("Text Area", "Minimum height", textArea);
+    }
+
+    private void textAreaHelperText() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: TextArea Helper Text and Component
+        TextArea textAreaHelperText = new TextArea();
+        textAreaHelperText.setPlaceholder("Write here ...");
+        textAreaHelperText.setHelperText("Helper Text");
+
+        TextArea textAreaHelperComponent = new TextArea();
+        textAreaHelperComponent.setPlaceholder("Write here ...");
+        textAreaHelperComponent.setHelperComponent(new Span("Helper Text"));
+
+        add(textAreaHelperText, textAreaHelperComponent);
+        // end-source-example
+
+        textAreaHelperText.setId("text-area-with-helper-text");
+        textAreaHelperText.getStyle().set("margin-right","20px");
+        div.add(textAreaHelperText, textAreaHelperComponent);
+        addCard("Text Area", "TextArea Helper Text and Component", div);
+    }
+
+    private void textAreaHelperTextVariant() {
+        Div div = new Div();
+        // begin-source-example
+        // source-example-heading: TextArea Helper Variant
+        TextArea textAreaBelow = new TextArea("Helper Text below the field");
+        textAreaBelow.setPlaceholder("Write here ...");
+        textAreaBelow.setHelperText("Helper Text");
+
+        TextArea textAreaAbove = new TextArea("Helper Text above the field");
+        textAreaAbove.setPlaceholder("Write here ...");
+        textAreaAbove.setHelperText("Helper Text");
+        textAreaAbove.addThemeVariants(TextAreaVariant.LUMO_HELPER_ABOVE_FIELD);
+
+        add(textAreaBelow, textAreaAbove);
+        // end-source-example
+
+        div.getStyle().set("display","flex");
+        textAreaBelow.getStyle().set("margin-right","20px");
+        div.add(textAreaBelow, textAreaAbove);
+
+        addCard("Text Area", "TextArea Helper Variant", div);
     }
 
     private void prefixAndSuffix() {

--- a/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
+++ b/vaadin-text-field-flow-demo/src/main/java/com/vaadin/flow/component/textfield/demo/TextFieldView.java
@@ -424,47 +424,48 @@ public class TextFieldView extends DemoView {
     private void textAreaHelperText() {
         Div div = new Div();
         // begin-source-example
-        // source-example-heading: Text area Helper Text and Component
+        // source-example-heading: Helper text and helper component
         TextArea textAreaHelperText = new TextArea("Overview");
         textAreaHelperText.setPlaceholder("Write here ...");
         textAreaHelperText
-              .setHelperText("Short description of your current position");
+              .setHelperText("Short description of your current role");
 
         TextArea textAreaHelperComponent = new TextArea("Feedback");
         textAreaHelperComponent.setPlaceholder("Write here ...");
         textAreaHelperComponent.setHelperComponent(new Span(
-              "Here you can share what you've liked and what can be improved in the next lesson"));
+              "Here you can share what you've liked and "
+                    + "what can be improved in the next lesson"));
 
         add(textAreaHelperText, textAreaHelperComponent);
         // end-source-example
 
         textAreaHelperText.setId("text-area-with-helper-text");
-        textAreaHelperText.getStyle().set("margin-right","20px");
+        textAreaHelperText.getStyle().set("margin-right", "20px");
         div.add(textAreaHelperText, textAreaHelperComponent);
-        addCard("Text Area", "Text area Helper Text and Component", div);
+        addCard("Text Area", "Helper text and helper component", div);
     }
 
     private void textAreaHelperTextVariant() {
         Div div = new Div();
         // begin-source-example
-        // source-example-heading: TextArea Helper Variant
-        TextArea textAreaBelow = new TextArea("Helper Text below the field");
+        // source-example-heading: Helper Variant
+        TextArea textAreaBelow = new TextArea();
         textAreaBelow.setPlaceholder("Write here ...");
-        textAreaBelow.setHelperText("Helper Text");
+        textAreaBelow.setHelperText("Helper Text is below the field");
 
-        TextArea textAreaAbove = new TextArea("Helper Text above the field");
+        TextArea textAreaAbove = new TextArea();
         textAreaAbove.setPlaceholder("Write here ...");
-        textAreaAbove.setHelperText("Helper Text");
+        textAreaAbove.setHelperText("Helper Text is above the field");
         textAreaAbove.addThemeVariants(TextAreaVariant.LUMO_HELPER_ABOVE_FIELD);
 
         add(textAreaBelow, textAreaAbove);
         // end-source-example
 
-        div.getStyle().set("display","flex");
-        textAreaBelow.getStyle().set("margin-right","20px");
+        div.getStyle().set("display", "flex");
+        textAreaBelow.getStyle().set("margin-right", "20px");
         div.add(textAreaBelow, textAreaAbove);
 
-        addCard("Text Area", "TextArea Helper Variant", div);
+        addCard("Text Area", "Helper Variant", div);
     }
 
     private void prefixAndSuffix() {

--- a/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-text-field-flow-integration-tests/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <groupId>com.vaadin</groupId>

--- a/vaadin-text-field-flow-integration-tests/pom.xml
+++ b/vaadin-text-field-flow-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-text-field-flow-integration-tests</artifactId>

--- a/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
+++ b/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextAreaPage.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.textfield.tests;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.router.Route;
 
@@ -47,6 +49,8 @@ public class TextAreaPage extends Div {
         addMaxHeightFeature();
         addMinHeightFeature();
         addInvalidCheck();
+        addHelperText();
+        addHelperComponent();
     }
 
     private void addFocusShortcut() {
@@ -113,4 +117,32 @@ public class TextAreaPage extends Div {
         TextFieldTestPageUtil.addInvalidCheck(this, field);
     }
 
+    private void addHelperText() {
+        TextArea field = new TextArea();
+        field.setHelperText("Helper text");
+        field.setId("helper-text-field");
+
+        NativeButton clearButton = new NativeButton(
+              "Clear helper text");
+        clearButton.setId("clear-helper-text-button");
+        clearButton.addClickListener(
+              event -> field.setHelperText(null));
+        add(field, clearButton);
+    }
+
+    private void addHelperComponent() {
+        TextArea field = new TextArea();
+        field.setLabel("Helper component should be visible");
+        Span span = new Span("Helper Component");
+        span.setId("helper-component");
+        field.setHelperComponent(span);
+        field.setId("helper-component-field");
+
+        NativeButton clearButton = new NativeButton(
+              "Clear helper component");
+        clearButton.setId("clear-helper-component-button");
+        clearButton.addClickListener(
+              event -> field.setHelperComponent(null));
+        add(field, clearButton);
+    }
 }

--- a/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextFieldPage.java
+++ b/vaadin-text-field-flow-integration-tests/src/main/java/com/vaadin/flow/component/textfield/tests/TextFieldPage.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 
@@ -81,6 +82,8 @@ public class TextFieldPage extends Div {
         addBasicFeatures();
         addFocusShortcut();
         addInvalidCheck();
+        addHelperText();
+        addHelperComponent();
     }
 
     private void handleTextFieldValue(TextField field) {
@@ -134,5 +137,35 @@ public class TextFieldPage extends Div {
         field.setMaxLength(10);
         field.setMinLength(5);
         TextFieldTestPageUtil.addInvalidCheck(this, field);
+    }
+
+    private void addHelperText() {
+        TextField  textField = new TextField();
+        textField.setLabel("Helper text should be visible");
+        textField.setHelperText("Helper text");
+        textField.setId("helper-text-field");
+
+        NativeButton clearButton = new NativeButton(
+              "Clear helper text");
+        clearButton.setId("clear-helper-text-button");
+        clearButton.addClickListener(
+              event -> textField.setHelperText(null));
+        add(textField, clearButton);
+    }
+
+    private void addHelperComponent() {
+        TextField  textField = new TextField();
+        textField.setLabel("Helper component should be visible");
+        Span span = new Span("Helper Component");
+        span.setId("helper-component");
+        textField.setHelperComponent(span);
+        textField.setId("helper-component-field");
+
+        NativeButton clearButton = new NativeButton(
+              "Clear helper component");
+        clearButton.setId("clear-helper-component-button");
+        clearButton.addClickListener(
+              event -> textField.setHelperComponent(null));
+        add(textField, clearButton);
     }
 }

--- a/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
+++ b/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextAreaPageIT.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -149,6 +150,36 @@ public class TextAreaPageIT extends AbstractComponentIT {
     public void assertCantMakeInvalidValueValidThroughClientManipulation() {
         ValidationTestHelper.testValidation(getCommandExecutor(), getContext(),
             $(TextAreaElement.class).id("invalid-test-field"));
+    }
+
+    @Test
+    public void assertHelperText () {
+        TextAreaElement textAreaElement = $(TextAreaElement.class).id("helper-text-field");
+        Assert.assertEquals("Helper text",textAreaElement.getHelperText());
+    }
+
+    @Test
+    public void clearHelper (){
+        TextAreaElement textAreaElement = $(TextAreaElement.class).id("helper-text-field");
+        Assert.assertEquals("Helper text",textAreaElement.getHelperText());
+
+        $(TestBenchElement.class).id("clear-helper-text-button").click();
+        Assert.assertEquals("", textAreaElement.getHelperText());
+    }
+
+    @Test
+    public void assertHelperComponent () {
+        TextAreaElement textAreaElement = $(TextAreaElement.class).id("helper-component-field");
+        Assert.assertEquals("helper-component",textAreaElement.getHelperComponent().getAttribute("id"));
+    }
+
+    @Test
+    public void clearHelperComponent(){
+        TextAreaElement textAreaElement = $(TextAreaElement.class).id("helper-component-field");
+        Assert.assertEquals("helper-component",textAreaElement.getHelperComponent().getAttribute("id"));
+
+        $(TestBenchElement.class).id("clear-helper-component-button").click();
+        Assert.assertNull(textAreaElement.getHelperComponent());
     }
 
 }

--- a/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
+++ b/vaadin-text-field-flow-integration-tests/src/test/java/com/vaadin/flow/component/textfield/tests/TextFieldPageIT.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,6 +153,36 @@ public class TextFieldPageIT extends AbstractComponentIT {
         Assert.assertTrue("TextField should be focused after the shortcut event is triggered.",
                 shortcutField.getAttribute("focused").equals("true")
                         || shortcutField.getAttribute("focused").equals(""));
+    }
+
+    @Test
+    public void assertHelperText () {
+        TextFieldElement textFieldElement = $(TextFieldElement.class).id("helper-text-field");
+        Assert.assertEquals("Helper text",textFieldElement.getHelperText());
+    }
+
+    @Test
+    public void clearHelper (){
+        TextFieldElement textFieldElement = $(TextFieldElement.class).id("helper-text-field");
+        Assert.assertEquals("Helper text",textFieldElement.getHelperText());
+
+        $(TestBenchElement.class).id("clear-helper-text-button").click();
+        Assert.assertEquals("", textFieldElement.getHelperText());
+    }
+
+    @Test
+    public void assertHelperComponent () {
+        TextFieldElement textFieldElement = $(TextFieldElement.class).id("helper-component-field");
+        Assert.assertEquals("helper-component",textFieldElement.getHelperComponent().getAttribute("id"));
+    }
+
+    @Test
+    public void clearHelperComponent(){
+        TextFieldElement textFieldElement = $(TextFieldElement.class).id("helper-component-field");
+        Assert.assertEquals("helper-component",textFieldElement.getHelperComponent().getAttribute("id"));
+
+        $(TestBenchElement.class).id("clear-helper-component-button").click();
+        Assert.assertNull(textFieldElement.getHelperComponent());
     }
 
     private void updateValues(WebElement textFieldValueDiv,

--- a/vaadin-text-field-flow-testbench/pom.xml
+++ b/vaadin-text-field-flow-testbench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-text-field-testbench</artifactId>

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/BigDecimalFieldElement.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.textfield.testbench;
 
 import java.util.Collections;
 
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -29,7 +30,7 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("vaadin-big-decimal-field")
 public class BigDecimalFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+        implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     @Override
     public void setValue(String string) {

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/EmailFieldElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -29,7 +30,7 @@ import java.util.Collections;
  */
 @Element("vaadin-email-field")
 public class EmailFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+        implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     @Override
     public void setValue(String string) {

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/IntegerFieldElement.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.textfield.testbench;
 
 import java.util.Collections;
 
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -29,7 +30,7 @@ import com.vaadin.testbench.elementsbase.Element;
  */
 @Element("vaadin-integer-field")
 public class IntegerFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+        implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     @Override
     public void setValue(String string) {

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/NumberFieldElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -29,7 +30,7 @@ import java.util.Collections;
  */
 @Element("vaadin-number-field")
 public class NumberFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+        implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     @Override
     public void setValue(String string) {

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -15,13 +15,14 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import java.util.Collections;
+
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
-
-import java.util.Collections;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-password-field&gt;</code>
@@ -29,7 +30,7 @@ import java.util.Collections;
  */
 @Element("vaadin-password-field")
 public class PasswordFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+      implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     /**
      * Checks whether the password is shown in clear text or is hidden from

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -29,7 +30,7 @@ import java.util.Collections;
  */
 @Element("vaadin-text-area")
 public class TextAreaElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+        implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
     @Override
     public void setValue(String string) {
         HasStringValueProperty.super.setValue(string);

--- a/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-text-field-flow-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -15,13 +15,14 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
+import java.util.Collections;
+
+import com.vaadin.testbench.HasHelper;
 import com.vaadin.testbench.HasLabel;
 import com.vaadin.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
-
-import java.util.Collections;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-text-field&gt;</code>
@@ -29,7 +30,7 @@ import java.util.Collections;
  */
 @Element("vaadin-text-field")
 public class TextFieldElement extends TestBenchElement
-        implements HasStringValueProperty, HasLabel, HasPlaceholder {
+      implements HasStringValueProperty, HasLabel, HasPlaceholder, HasHelper {
 
     @Override
     public void setValue(String string) {

--- a/vaadin-text-field-flow/pom.xml
+++ b/vaadin-text-field-flow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-text-field-flow-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-text-field-flow</artifactId>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-text-field</artifactId>
-            <version>2.6.2</version>
+            <version>2.8.0-alpha1</version>
         </dependency>
 
         <dependency>

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/AbstractNumberField.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -38,7 +39,7 @@ public abstract class AbstractNumberField<C extends AbstractNumberField<C, T>, T
         extends GeneratedVaadinNumberField<C, T>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
 
     private ValueChangeMode currentMode;
 

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/BigDecimalField.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -54,7 +55,7 @@ public class BigDecimalField
         extends GeneratedVaadinTextField<BigDecimalField, BigDecimal>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/EmailField.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -34,7 +35,7 @@ public class EmailField
         extends GeneratedVaadinEmailField<EmailField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
     private static final String EMAIL_PATTERN = "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$";
 
     private ValueChangeMode currentMode;

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinEmailField.java
@@ -52,7 +52,7 @@ import javax.annotation.Generated;
         "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-email-field")
 @HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-email-field.html")
-@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.6.2")
+@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.8.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-email-field.js")
 public abstract class GeneratedVaadinEmailField<R extends GeneratedVaadinEmailField<R, T>, T>
         extends GeneratedVaadinTextField<R, T> implements HasStyle {

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinNumberField.java
@@ -43,7 +43,7 @@ import javax.annotation.Generated;
         "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-number-field")
 @HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-number-field.html")
-@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.6.2")
+@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.8.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-number-field.js")
 public abstract class GeneratedVaadinNumberField<R extends GeneratedVaadinNumberField<R, T>, T>
         extends GeneratedVaadinTextField<R, T> implements HasStyle {

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinPasswordField.java
@@ -88,7 +88,7 @@ import javax.annotation.Generated;
         "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-password-field")
 @HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-password-field.html")
-@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.6.2")
+@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.8.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-password-field.js")
 public abstract class GeneratedVaadinPasswordField<R extends GeneratedVaadinPasswordField<R, T>, T>
         extends GeneratedVaadinTextField<R, T> implements HasStyle {

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -149,7 +149,7 @@ import java.util.stream.Stream;
         "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-text-area")
 @HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-text-area.html")
-@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.6.2")
+@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.8.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-text-area.js")
 public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<R, T>, T>
         extends AbstractSinglePropertyField<R, T>

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -173,7 +173,7 @@ import java.util.stream.Stream;
         "Flow#1.3-SNAPSHOT" })
 @Tag("vaadin-text-field")
 @HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-text-field.html")
-@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.6.2")
+@NpmPackage(value = "@vaadin/vaadin-text-field", version = "2.8.0-alpha1")
 @JsModule("@vaadin/vaadin-text-field/src/vaadin-text-field.js")
 public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextField<R, T>, T>
         extends AbstractSinglePropertyField<R, T>

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/PasswordField.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -34,7 +35,7 @@ public class PasswordField
         extends GeneratedVaadinPasswordField<PasswordField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextArea.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -32,7 +33,7 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextArea extends GeneratedVaadinTextArea<TextArea, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextAreaVariant.java
@@ -25,7 +25,9 @@ import javax.annotation.Generated;
         "Flow#1.3-SNAPSHOT" })
 public enum TextAreaVariant {
     LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
-            "align-right"), MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
+          "align-right"), LUMO_HELPER_ABOVE_FIELD(
+          "helper-above-field"), MATERIAL_ALWAYS_FLOAT_LABEL(
+          "always-float-label");
 
     private final String variant;
 

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextField.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.textfield;
 
 import com.vaadin.flow.component.CompositionNotifier;
+import com.vaadin.flow.component.HasHelper;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.InputNotifier;
@@ -32,7 +33,7 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 public class TextField extends GeneratedVaadinTextField<TextField, String>
         implements HasSize, HasValidation, HasValueChangeMode,
         HasPrefixAndSuffix, InputNotifier, KeyNotifier, CompositionNotifier,
-        HasAutocomplete, HasAutocapitalize, HasAutocorrect {
+        HasAutocomplete, HasAutocapitalize, HasAutocorrect, HasHelper {
     private ValueChangeMode currentMode;
 
     private boolean isConnectorAttached;

--- a/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
+++ b/vaadin-text-field-flow/src/main/java/com/vaadin/flow/component/textfield/TextFieldVariant.java
@@ -25,7 +25,8 @@ import javax.annotation.Generated;
         "Flow#1.3-SNAPSHOT" })
 public enum TextFieldVariant {
     LUMO_SMALL("small"), LUMO_ALIGN_CENTER("align-center"), LUMO_ALIGN_RIGHT(
-            "align-right"), MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
+            "align-right"), LUMO_HELPER_ABOVE_FIELD(
+          "helper-above-field"), MATERIAL_ALWAYS_FLOAT_LABEL("always-float-label");
 
     private final String variant;
 


### PR DESCRIPTION
- Each component extends `HasHelper`
- Version of a `vaadin-text-field` is `2.8.0-alpha1`
- A HelperVariant to TextAreaVariant and TextFieldVariant to display helper text above
- Demos for `TextField` and `TextArea`
- Tests for `TextField` and `TextArea`
- Bump all version by 0.1

Fixes https://github.com/vaadin/vaadin-text-field-flow/issues/316

following for references https://github.com/vaadin/vaadin-radio-button-flow/pull/140

Change on client-side is included with [`2.8.0-alpha1`](https://github.com/vaadin/vaadin-text-field/commit/1f5b7b11c7f94c752a314547426867938ea58a90). [Release notes](https://github.com/vaadin/vaadin-text-field/releases/tag/v2.8.0-alpha1)